### PR TITLE
Update walker.php

### DIFF
--- a/Lesson 18/inc/walker.php
+++ b/Lesson 18/inc/walker.php
@@ -27,7 +27,7 @@ class Sunset_Walker_Nav_Primary extends Walker_Nav_menu {
 		$classes = empty( $item->classes ) ? array() : (array) $item->classes;
 		
 		$classes[] = ($args->walker->has_children) ? 'dropdown' : '';
-		$classes[] = ($item->current || $item->current_item_anchestor) ? 'active' : '';
+		$classes[] = ($item->current || $item->current_item_ancestor) ? 'active' : '';
 		$classes[] = 'menu-item-' . $item->ID;
 		if( $depth && $args->walker->has_children ){
 			$classes[] = 'dropdown-submenu';


### PR DESCRIPTION
Spelling error found by @mbsvpn in WordPress101 tutorial code that's been carried over to this lesson. Without current_item_ancestor the top level of the menu does not receive the "active" class and thus not highlighted/underlined when navigating to it's the sub menu page.
